### PR TITLE
Fixed nodejs build

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -12,7 +12,7 @@ blocks:
           commands:
             - sem-version java 11
             - sem-service start postgres
-            - ./gradlew build --info
+            - ./gradlew build --scan
       env_vars:
         - name: TERM
           value: dumb
@@ -21,7 +21,6 @@ blocks:
       prologue:
         commands:
           - echo $DOCKER_PASSWORD | docker login --username "$DOCKER_USERNAME" --password-stdin
-          - sem-version node 16.5.0
           - checkout
           - cache restore $(checksum build.gradle)
           - cache restore $(checksum src/webapp/package-lock.json)

--- a/README.md
+++ b/README.md
@@ -60,18 +60,3 @@ Then install the dependencies by running `pip install -r requirements.txt` in th
 
 To run the docs in dev mode, run the command `mkdocs serve`.
 
-## Using NVM on linux
-
-To use NVM on linux you'll need to configure /usr/bin/node, /usr/bin/npx and /usr/bin/npm so that IntelliJ can detect them.
-
-To do this, add the env variable `export NVM_SYMLINK_CURRENT=true` above the NVM snippet in your `~/.bashrc`, `~/.zshrc` or equivalent file.
-
-This will configure a symlink to the current node directory `~/.nvm/current`.
-
-You can then use this to configure `/usr/bin` symlinks:
-
-```bash
-sudo ln -s ~/.nvm/current/bin/node /usr/bin/node
-sudo ln -s ~/.nvm/current/bin/npm /usr/bin/npm
-sudo ln -s ~/.nvm/current/bin/npx /usr/bin/npx
-```

--- a/app.json
+++ b/app.json
@@ -22,6 +22,10 @@
     "REMEMBER_ME_KEY": {
       "description": "Remember me token key.",
       "value": "sometoken"
+    },
+    "ADMIN_USER_EMAIL": {
+      "description": "Email to use for the default admin user",
+      "value": "support@happyvalley.io"
     }
   },
   "formation": {

--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,11 @@ buildscript {
     }
 }
 
+buildScan {
+    termsOfServiceUrl = 'https://gradle.com/terms-of-service'
+    termsOfServiceAgree = 'yes'
+}
+
 plugins {
     id 'org.springframework.boot' version '2.5.2'
     id 'io.spring.dependency-management' version '1.0.11.RELEASE'

--- a/build.gradle
+++ b/build.gradle
@@ -135,7 +135,8 @@ task copyAssets(type: Copy) {
 }
 
 node {
-    download = false
+    download = true
+    version = "16.9.0" // If you'd like to be on LTS then it'll break the download for M1 macs.
     nodeModulesDir = file(buildAssetsDir)
     npmInstallCommand = 'ci'
 }

--- a/src/webapp/cypress.json
+++ b/src/webapp/cypress.json
@@ -4,7 +4,6 @@
   "chromeWebSecurity": false,
   "trashAssetsBeforeRuns": true,
   "defaultCommandTimeout": 30000,
-  "screenshotsFolder": "/tmp/cypress",
   "retries": {
     "runMode": 3,
     "openMode": 0


### PR DESCRIPTION
We now always download nodejs per project. This makes building for the first time much simpler, and leads to less configuration required for heroku deployment. It will fix the issues we currently have with the heroku review apps.