### PR TITLE
Fixing the hardcoded localhost variable

### DIFF
--- a/app.json
+++ b/app.json
@@ -26,6 +26,10 @@
     "ADMIN_USER_EMAIL": {
       "description": "Email to use for the default admin user",
       "value": "support@happyvalley.io"
+    },
+    "APP_BASE_URL": {
+      "description": "Base url to use for any email links (e.g. password reset)",
+      "value": "https://koil-sample.herokuapp.com"
     }
   },
   "formation": {

--- a/src/main/kotlin/org/koil/auth/AuthService.kt
+++ b/src/main/kotlin/org/koil/auth/AuthService.kt
@@ -1,6 +1,6 @@
 package org.koil.auth
 
-import org.koil.notifications.NotificationService
+import org.koil.notifications.EmailNotificationService
 import org.koil.user.AccountRepository
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Component
@@ -25,7 +25,7 @@ interface AuthService {
 
 @Component
 class AuthServiceImpl(
-    private val notifications: NotificationService,
+    private val notifications: EmailNotificationService,
     private val passwordEncoder: PasswordEncoder,
     private val accountRepository: AccountRepository
 ) : AuthService {

--- a/src/main/kotlin/org/koil/notifications/EmailNotificationService.kt
+++ b/src/main/kotlin/org/koil/notifications/EmailNotificationService.kt
@@ -1,0 +1,64 @@
+package org.koil.notifications
+
+import org.koil.user.Account
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.mail.javamail.JavaMailSender
+import org.springframework.mail.javamail.MimeMessageHelper
+import org.springframework.stereotype.Component
+import java.util.*
+
+interface NotificationService {
+    fun sendAccountCreationConfirmation(account: Account)
+    fun sendPasswordResetEmail(email: String, code: UUID)
+}
+
+@Component
+class EmailNotificationService(
+    private val sender: JavaMailSender,
+    private val views: PebbleEmailViews,
+    @Value("\${mail.fromAddress}") private val fromAddress: String,
+    @Value("\${mail.base-url}") private val baseUrl: String
+) : NotificationService {
+    override fun sendAccountCreationConfirmation(account: Account) {
+        val model = AccountCreationNotificationViewModel(
+            defaults = EmailDefaults(
+                "Welcome to koil!",
+                "Happy Valley IO Ltd, 2 Melville Street, Falkirk, FK1 1HZ",
+                "%unsubscribe_link%"
+            ),
+            title = "Welcome to koil!",
+            subtitle = "We're happy to have you!",
+            footer = "Get in touch if you have any trouble!"
+        )
+
+        sendMessage(views.renderWelcomeMessage(model), account.emailAddress, model.title)
+    }
+
+    override fun sendPasswordResetEmail(email: String, code: UUID) {
+        val model = PasswordResetViewModel(
+            defaults = EmailDefaults(
+                "Password reset link",
+                "Happy Valley IO Ltd, 2 Melville Street, Falkirk, FK1 1HZ",
+                "%unsubscribe_link%"
+            ),
+            baseUrl = baseUrl,
+            code = code,
+            appName = "koil"
+        )
+
+        sendMessage(views.renderPasswordReset(model), email, "Password reset link")
+    }
+
+    private fun sendMessage(html: String, to: String, subject: String) {
+        val message = sender.createMimeMessage()
+
+        val helper = MimeMessageHelper(message, "utf-8")
+
+        helper.setText(html, true)
+        helper.setTo(to)
+        helper.setSubject(subject)
+        helper.setFrom(fromAddress)
+
+        sender.send(message)
+    }
+}

--- a/src/main/kotlin/org/koil/notifications/Models.kt
+++ b/src/main/kotlin/org/koil/notifications/Models.kt
@@ -1,0 +1,35 @@
+package org.koil.notifications
+
+import org.springframework.web.util.UriComponentsBuilder
+import java.util.*
+
+
+data class EmailDefaults(val clientPreviewText: String, val companyDetails: String, val unsubscribeLink: String)
+
+data class NotificationAlertSuccessModel(
+    val defaults: EmailDefaults,
+    val title: String,
+    val headline: String,
+    val actionUrl: String,
+    val actionText: String,
+    val thankYouText: String
+)
+
+data class AccountCreationNotificationViewModel(
+    val defaults: EmailDefaults,
+    val subtitle: String,
+    val footer: String,
+    val title: String
+)
+
+data class PasswordResetViewModel(
+    val defaults: EmailDefaults,
+    val baseUrl: String,
+    val appName: String,
+    val code: UUID
+) {
+    val resetLink: String = UriComponentsBuilder.fromUriString("$baseUrl/auth/password-reset")
+        .queryParam("code", code)
+        .build()
+        .toUriString()
+}

--- a/src/main/kotlin/org/koil/notifications/NotificationListener.kt
+++ b/src/main/kotlin/org/koil/notifications/NotificationListener.kt
@@ -1,36 +1,9 @@
 package org.koil.notifications
 
-import com.mitchellbosecke.pebble.PebbleEngine
-import org.koil.user.Account
 import org.koil.user.AccountCreationEvent
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.event.EventListener
-import org.springframework.mail.javamail.JavaMailSender
-import org.springframework.mail.javamail.MimeMessageHelper
 import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Component
-import java.io.StringWriter
-import java.net.URLEncoder
-import java.util.*
-
-data class EmailDefaults(val clientPreviewText: String, val companyDetails: String, val unsubscribeLink: String)
-data class NotificationAlertSuccessModel(
-    val defaults: EmailDefaults,
-    val title: String,
-    val headline: String,
-    val actionUrl: String,
-    val actionText: String,
-    val thankYouText: String
-)
-
-data class AccountCreationNotificationModel(
-    val defaults: EmailDefaults,
-    val subtitle: String,
-    val footer: String,
-    val title: String
-)
-
-data class PasswordResetModel(val defaults: EmailDefaults, val resetLink: String, val appName: String)
 
 @Component
 class NotificationListener(val notifications: NotificationService) {
@@ -39,75 +12,4 @@ class NotificationListener(val notifications: NotificationService) {
     fun onAccountCreation(event: AccountCreationEvent) {
         notifications.sendAccountCreationConfirmation(event.account)
     }
-}
-
-@Component
-class NotificationService(
-    private val sender: JavaMailSender,
-    private val views: EmailViews,
-    @Value("\${mail.fromAddress}") private val fromAddress: String
-) {
-    fun sendAccountCreationConfirmation(account: Account) {
-        val model = AccountCreationNotificationModel(
-            defaults = EmailDefaults(
-                "Welcome to koil!",
-                "Happy Valley IO Ltd, 2 Melville Street, Falkirk, FK1 1HZ",
-                "%unsubscribe_link%"
-            ),
-            title = "Welcome to koil!",
-            subtitle = "We're happy to have you!",
-            footer = "Get in touch if you have any trouble!"
-        )
-
-        sendMessage(views.renderWelcomeMessage(model), account.emailAddress, model.title)
-    }
-
-    fun sendPasswordResetEmail(email: String, code: UUID?) {
-        val url = "http://localhost:8080/auth/password-reset?code=" + URLEncoder.encode(code.toString(), "UTF-8")
-        val model = PasswordResetModel(
-            defaults = EmailDefaults(
-                "Password reset link",
-                "Happy Valley IO Ltd, 2 Melville Street, Falkirk, FK1 1HZ",
-                "%unsubscribe_link%"
-            ),
-            resetLink = url,
-            appName = "koil"
-        )
-
-        sendMessage(views.renderPasswordReset(model), email, "Password reset link")
-    }
-
-    private fun sendMessage(html: String, to: String, subject: String) {
-        val message = sender.createMimeMessage()
-
-        val helper = MimeMessageHelper(message, "utf-8")
-
-        helper.setText(html, true)
-        helper.setTo(to)
-        helper.setSubject(subject)
-        helper.setFrom(fromAddress)
-
-        sender.send(message)
-    }
-}
-
-@Component
-class EmailViews(val pebble: PebbleEngine) {
-    fun renderAlertSuccess(model: NotificationAlertSuccessModel): String {
-        return pebble.renderWithModel("email/alert-success-inlined", mapOf("model" to model))
-    }
-
-    fun renderWelcomeMessage(model: AccountCreationNotificationModel): String {
-        return pebble.renderWithModel("email/welcome-inlined", mapOf("model" to model))
-    }
-
-    fun renderPasswordReset(model: PasswordResetModel): String {
-        return pebble.renderWithModel("email/password-inlined", mapOf("model" to model))
-    }
-}
-
-fun PebbleEngine.renderWithModel(template: String, model: Map<String, Any?>): String {
-    val writer = StringWriter()
-    this.getTemplate(template).evaluate(writer, model)
-    return writer.toString()
 }

--- a/src/main/kotlin/org/koil/notifications/PebbleEmailViews.kt
+++ b/src/main/kotlin/org/koil/notifications/PebbleEmailViews.kt
@@ -1,0 +1,32 @@
+package org.koil.notifications
+
+import com.mitchellbosecke.pebble.PebbleEngine
+import org.springframework.stereotype.Component
+import java.io.StringWriter
+
+interface EmailViews {
+    fun renderAlertSuccess(model: NotificationAlertSuccessModel): String
+    fun renderWelcomeMessage(model: AccountCreationNotificationViewModel): String
+    fun renderPasswordReset(model: PasswordResetViewModel): String
+}
+
+@Component
+class PebbleEmailViews(val pebble: PebbleEngine) : EmailViews {
+    override fun renderAlertSuccess(model: NotificationAlertSuccessModel): String {
+        return pebble.renderWithModel("email/alert-success-inlined", mapOf("model" to model))
+    }
+
+    override fun renderWelcomeMessage(model: AccountCreationNotificationViewModel): String {
+        return pebble.renderWithModel("email/welcome-inlined", mapOf("model" to model))
+    }
+
+    override fun renderPasswordReset(model: PasswordResetViewModel): String {
+        return pebble.renderWithModel("email/password-inlined", mapOf("model" to model))
+    }
+
+    private fun PebbleEngine.renderWithModel(template: String, model: Map<String, Any?>): String {
+        val writer = StringWriter()
+        this.getTemplate(template).evaluate(writer, model)
+        return writer.toString()
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -20,7 +20,9 @@ spring.mail.password=${MAILGUN_SMTP_PASSWORD:}
 spring.mail.properties.mail.smtp.auth=true
 spring.mail.properties.mail.smtp.starttls.enable=true
 mail.fromAddress=koil <noreply@getkoil.dev>
+mail.base-url=${APP_BASE_URL}
 spring.main.log-startup-info=false
 admin-user.email=${ADMIN_USER_EMAIL:}
 
 auth.remember-me.key=${REMEMBER_ME_KEY}
+

--- a/src/main/resources/templates/email/password-inlined.peb
+++ b/src/main/resources/templates/email/password-inlined.peb
@@ -1,4 +1,4 @@
-{# @pebvariable name="model" type="org.koil.notifications.PasswordResetModel" #}
+{# @pebvariable name="model" type="org.koil.notifications.PasswordResetViewModel" #}
 <!doctype html>
 <html>
 <head>

--- a/src/main/resources/templates/email/welcome-inlined.peb
+++ b/src/main/resources/templates/email/welcome-inlined.peb
@@ -1,4 +1,4 @@
-{# @pebvariable name="model" type="org.koil.notifications.AccountCreationNotificationModel" #}
+{# @pebvariable name="model" type="org.koil.notifications.AccountCreationNotificationViewModel" #}
 
 <!doctype html>
 <html>

--- a/src/test/kotlin/org/koil/dev/EmailDevController.kt
+++ b/src/test/kotlin/org/koil/dev/EmailDevController.kt
@@ -1,14 +1,15 @@
 package org.koil.dev
 
-import org.koil.notifications.AccountCreationNotificationModel
+import org.koil.notifications.AccountCreationNotificationViewModel
 import org.koil.notifications.EmailDefaults
 import org.koil.notifications.NotificationAlertSuccessModel
-import org.koil.notifications.PasswordResetModel
+import org.koil.notifications.PasswordResetViewModel
 import org.springframework.context.annotation.Profile
 import org.springframework.stereotype.Controller
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.servlet.ModelAndView
+import java.util.*
 
 @Controller
 @Profile("dev")
@@ -41,7 +42,7 @@ class EmailDevController {
         return ModelAndView(
             "email/welcome-inlined",
             mapOf(
-                "model" to AccountCreationNotificationModel(
+                "model" to AccountCreationNotificationViewModel(
                     defaults = EmailDefaults(
                         "A new post for you to read",
                         "Happy Valley IO Ltd, 2 Melville Street, Falkirk, FK1 1HZ",
@@ -60,14 +61,15 @@ class EmailDevController {
         return ModelAndView(
             "email/password-inlined",
             mapOf(
-                "model" to PasswordResetModel(
+                "model" to PasswordResetViewModel(
                     defaults = EmailDefaults(
                         "Password reset link",
                         "Happy Valley IO Ltd, 2 Melville Street, Falkirk, FK1 1HZ",
                         "%unsubscribe_link%"
                     ),
-                    resetLink = "http://localhost:8080/auth/login",
-                    appName = "koil"
+                    baseUrl = "http://localhost:8080/",
+                    appName = "koil",
+                    code = UUID.randomUUID()
                 )
             )
         )

--- a/src/test/kotlin/org/koil/notifications/PasswordResetViewModelTest.kt
+++ b/src/test/kotlin/org/koil/notifications/PasswordResetViewModelTest.kt
@@ -1,0 +1,34 @@
+package org.koil.notifications
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import org.junit.jupiter.api.Test
+import java.util.*
+
+class PasswordResetViewModelTest {
+    @Test
+    internal fun `generate the url given various baseUrls`() {
+        val code = UUID.randomUUID()
+
+        val happyPath = PasswordResetViewModel(
+            defaults = EmailDefaults("Preview", "Company", "test"),
+            baseUrl = "http://localhost:8080",
+            appName = "Koil",
+            code = code
+        )
+
+        assertThat(happyPath.resetLink).isEqualTo("http://localhost:8080/auth/password-reset?code=$code")
+
+        val withTrailingSlash = happyPath.copy(baseUrl = "http://localhost:8080/")
+        assertThat(withTrailingSlash.resetLink).isEqualTo("http://localhost:8080/auth/password-reset?code=$code")
+
+        val withoutPort = happyPath.copy(baseUrl = "http://localhost")
+        assertThat(withoutPort.resetLink).isEqualTo("http://localhost/auth/password-reset?code=$code")
+
+        val withPath = happyPath.copy(baseUrl = "https://www.example.com/test")
+        assertThat(withPath.resetLink).isEqualTo("https://www.example.com/test/auth/password-reset?code=$code")
+
+        val withPathAndTrailingSlash = happyPath.copy(baseUrl = "https://www.example.com/test/")
+        assertThat(withPathAndTrailingSlash.resetLink).isEqualTo("https://www.example.com/test/auth/password-reset?code=$code")
+    }
+}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -9,4 +9,5 @@ mail.fromAddress=koil <noreply@getkoil.dev>
 admin-user.email=admin@getkoil.dev
 admin-user.password=SecurePass123!
 auth.remember-me.key=REMEMBER_ME_KEY
+mail.base-url=http://localhost:8080
 spring.data.web.pageable.max-page-size=1000000000


### PR DESCRIPTION
I've also smuggled in some refactoring here. There's a further refactor needed to move more of the logic into the email viewmodels so that we don't have to attempt to test based off of teh email views. Alternatively, we can add regression tests to the email views where we save the generated HTML email in test resources and require them to be "re-recorded" on a change.