### PR TITLE
Admin users can make modifications to user settings

### DIFF
--- a/src/main/kotlin/org/koil/admin/AdminViews.kt
+++ b/src/main/kotlin/org/koil/admin/AdminViews.kt
@@ -1,5 +1,6 @@
 package org.koil.admin
 
+import org.koil.auth.AuthAuthority
 import org.koil.user.Account
 import org.koil.view.PaginatedViewModel
 import org.springframework.data.domain.Page
@@ -8,7 +9,15 @@ import org.springframework.web.servlet.ModelAndView
 data class AdminIndexViewModel(val userName: String, val accounts: Page<Account>) :
     PaginatedViewModel<Account>(accounts)
 
-data class AdminAccountDetailsViewModel(val userName: String, val account: Account)
+data class AdminAccountDetailsViewModel(
+    val account: Account,
+    val updated: Boolean = false,
+    val emailAlreadyTaken: Boolean = false
+) {
+    val possibleAuthorities: List<Pair<AuthAuthority, Boolean>> = AuthAuthority.values().map { authority ->
+        authority to account.authorities.map { it.authority }.contains(authority)
+    }
+}
 
 sealed class AdminViews<T>(private val template: String) {
 

--- a/src/main/kotlin/org/koil/admin/Models.kt
+++ b/src/main/kotlin/org/koil/admin/Models.kt
@@ -1,0 +1,9 @@
+package org.koil.admin
+
+import org.koil.user.Account
+
+sealed class AdminAccountUpdateResult {
+    data class AccountUpdateSuccess(val account: Account) : AdminAccountUpdateResult()
+    data class EmailAlreadyTaken(val account: Account) : AdminAccountUpdateResult()
+    object CouldNotFindAccount : AdminAccountUpdateResult()
+}

--- a/src/main/kotlin/org/koil/admin/accounts/AdminAccountsController.kt
+++ b/src/main/kotlin/org/koil/admin/accounts/AdminAccountsController.kt
@@ -1,18 +1,43 @@
 package org.koil.admin.accounts
 
+import org.hibernate.validator.constraints.Length
 import org.koil.admin.AdminAccountDetailsViewModel
+import org.koil.admin.AdminAccountUpdateResult
 import org.koil.admin.AdminViews
 import org.koil.admin.IAdminService
+import org.koil.auth.AuthAuthority
+import org.koil.user.Account
+import org.koil.user.AccountAuthority
 import org.koil.user.EnrichedUserDetails
 import org.springframework.http.HttpStatus
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.stereotype.Controller
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.validation.BindingResult
+import org.springframework.web.bind.annotation.*
 import org.springframework.web.server.ResponseStatusException
 import org.springframework.web.servlet.ModelAndView
+import javax.validation.Valid
+import javax.validation.constraints.Email
+import javax.validation.constraints.NotEmpty
 
+data class UpdateAccountRequest(
+    @get:NotEmpty(message = "Name cannot be empty") val fullName: String,
+    @get:Email(message = "Must be a valid email address") val email: String,
+    @get:Length(min = 4, max = 16, message = "Handle must be between 4 and 16 chars long") val handle: String,
+    val authorities: List<AuthAuthority>
+) {
+    val normalizedEmail: String = email.trim().toLowerCase()
+
+    fun update(account: Account): Account =
+        account.copy(
+            fullName = fullName,
+            emailAddress = normalizedEmail,
+            handle = handle,
+            authorities = authorities.map {
+                AccountAuthority(it)
+            }
+        )
+}
 
 @Controller
 @RequestMapping("/admin")
@@ -20,14 +45,47 @@ class AdminAccountsController(private val adminService: IAdminService) {
     @GetMapping("/accounts/{accountId}")
     fun adminAccountDetails(
         @AuthenticationPrincipal user: EnrichedUserDetails,
-        @PathVariable("accountId") accountId: Long
+        @PathVariable("accountId") accountId: Long,
+        @RequestParam("updated", defaultValue = "false") updated: Boolean
     ): ModelAndView {
         val account = adminService.getAccount(user.accountId, accountId)
 
         return if (account != null) {
-            AdminViews.AdminAccountDetailsView.render(AdminAccountDetailsViewModel(user.handle, account))
+            AdminViews.AdminAccountDetailsView.render(AdminAccountDetailsViewModel(account, updated))
         } else {
             throw ResponseStatusException(HttpStatus.NOT_FOUND, "Unable to find resource")
+        }
+    }
+
+    @PostMapping("/accounts/{accountId}")
+    fun updateAccountDetails(
+        @AuthenticationPrincipal user: EnrichedUserDetails,
+        @PathVariable("accountId") accountId: Long,
+        @Valid @ModelAttribute("submitted") submitted: UpdateAccountRequest,
+        bindingResult: BindingResult
+    ): ModelAndView {
+        if (bindingResult.hasErrors()) {
+            val account = adminService.getAccount(user.accountId, accountId)
+                ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "Unable to find resource")
+
+            return AdminViews.AdminAccountDetailsView.render(AdminAccountDetailsViewModel(account, false))
+                .apply { status = HttpStatus.BAD_REQUEST }
+        }
+
+        return when (val result = adminService.updateAccount(user.accountId, accountId, submitted)) {
+            is AdminAccountUpdateResult.AccountUpdateSuccess -> {
+                ModelAndView("redirect:/admin/accounts/$accountId?updated=true")
+            }
+            AdminAccountUpdateResult.CouldNotFindAccount -> {
+                throw ResponseStatusException(
+                    HttpStatus.NOT_FOUND,
+                    "Unable to find resource"
+                )
+            }
+            is AdminAccountUpdateResult.EmailAlreadyTaken -> AdminViews.AdminAccountDetailsView.render(
+                AdminAccountDetailsViewModel(result.account, updated = false, emailAlreadyTaken = true)
+            )
+                .apply { status = HttpStatus.BAD_REQUEST }
         }
     }
 }

--- a/src/main/kotlin/org/koil/user/Models.kt
+++ b/src/main/kotlin/org/koil/user/Models.kt
@@ -45,7 +45,7 @@ data class UpdateUserSettingsRequest(
 }
 
 @Table("account_authorities")
-data class AccountAuthority(val authority: AuthAuthority, val authorityGranted: Instant)
+data class AccountAuthority(val authority: AuthAuthority, val authorityGranted: Instant = Instant.now())
 
 @Table("accounts")
 data class Account(

--- a/src/main/resources/templates/components/form/errors.peb
+++ b/src/main/resources/templates/components/form/errors.peb
@@ -1,0 +1,5 @@
+{% macro errors(errors) %}
+    {% for err in errors %}
+    <small class="warning">{{ err }}</small>
+    {% endfor %}
+{% endmacro %}

--- a/src/main/resources/templates/pages/admin/accounts/account-details.peb
+++ b/src/main/resources/templates/pages/admin/accounts/account-details.peb
@@ -1,39 +1,72 @@
 {# @pebvariable name="model" type="org.koil.admin.AdminAccountDetailsViewModel" #}
+{# @pebvariable name="submitted" type="org.koil.admin.accounts.UpdateAccountRequest" #}
 
     {% extends "layouts/admin-layout" %}
     {% block title %} Admin | {{ model.account.fullName }} {% endblock %}
     {% import "components/help-tooltip" %}
+    {% import "components/form/errors" %}
 
 {% block content %}
 <div>
     <small><a href="/admin">Back to all accounts</a></small>
-    <h3>User Details</h3>
-    <form>
+    <hgroup>
+        <h3>User Details</h3>
+
+        {% if model.updated %}
+            <h4>
+                <mark data-test="update-confirmed">User account was updated successfully.</mark>
+            </h4>
+        {% endif %}
+    </hgroup>
+
+    <form method="POST" data-test="user-details-form">
+        {% include "components/csrf-field" %}
         <label>
             Full Name
-            <input type="text" name="fullName" value="{{ model.account.fullName }}" readonly>
+            <input type="text" name="fullName" maxlength="64"
+                   value="{{ submitted.fullName | default(model.account.fullName) }}"
+                   required>
+
+            {{ errors(getFieldErrors('submitted', 'fullName')) }}
         </label>
 
         <label>
             Email Address
-            <input type="email" name="email" value="{{ model.account.emailAddress }}" readonly>
+            <input type="email" name="email" value="{{ submitted.email | default(model.account.emailAddress) }}"
+                   required>
+            {{ errors(getFieldErrors('submitted', 'email')) }}
+            {% if model.emailAlreadyTaken %}
+                <small class="warning" data-test="email-taken">
+                    It looks like this email is already taken. Please try another.
+                </small>
+            {% endif %}
         </label>
-
 
         <label>
             Handle
-            <input type="email" name="email" value="{{ model.account.emailAddress }}" readonly>
+            <input type="text" name="handle" maxlength="16" minlength="4"
+                   value="{{ submitted.handle | default(model.account.handle) }}" required>
+            {{ errors(getFieldErrors('submitted', 'handle')) }}
         </label>
 
-        <label>
-            Roles & Authorities
-            {{ helptooltip(text="What can this user do?") }}
-            <ul>
-                    {% for role in model.account.authorities %}
-                    <li>{{ role.authority }}</li>
-                    {% endfor %}
-            </ul>
-        </label>
+        <fieldset>
+            <legend> Roles & Authorities
+                {{ helptooltip(text="What can this user do?") }}
+            </legend>
+            {% for role in model.possibleAuthorities %}
+                <label>
+                    <input type="checkbox" name="authorities" value="{{ role.first }}" {% if role.second %}
+                           checked
+                    {% endif %}>
+                    {{role.first}}
+                </label>
+            {% endfor %}
+        </fieldset>
+
+        <div class="grid">
+            <button type="submit">Update User</button>
+            <button type="reset" class="secondary">Cancel</button>
+        </div>
     </form>
 
     <h3>Actions</h3>

--- a/src/main/resources/templates/pages/login.peb
+++ b/src/main/resources/templates/pages/login.peb
@@ -21,7 +21,7 @@
         <label>
             <i class="fas fa-envelope"></i> Email Address
             <input type="email" name="email" value="{{ model.email }}"
-                   data-test="login-email-input">
+                   data-test="login-email-input" autofocus>
 
             <small class="warning">{{ model.errors.get("email") }}</small>
         </label>

--- a/src/main/resources/templates/pages/register.peb
+++ b/src/main/resources/templates/pages/register.peb
@@ -31,7 +31,9 @@
             <input type="email" name="email" value="{{ model.attempt.email }}"
                    data-test="email-input">
 
-            <small class="help is-danger">{{ model.errors.get("email") }}</small>
+            {% if model.errors.containsKey("email") %}
+                <small class="warning" data-test="email-error">{{ model.errors.get("email") }}</small>
+            {% endif %}
         </label>
 
 

--- a/src/test/kotlin/org/koil/admin/accounts/AdminAccountsControllerTest.kt
+++ b/src/test/kotlin/org/koil/admin/accounts/AdminAccountsControllerTest.kt
@@ -1,0 +1,32 @@
+package org.koil.admin.accounts
+
+import org.junit.jupiter.api.Test
+import org.koil.BaseIntegrationTest
+import org.koil.auth.AuthAuthority
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user
+import org.springframework.test.web.servlet.post
+
+class AdminAccountsControllerTest : BaseIntegrationTest() {
+    @Test
+    internal fun `bad inputs result in a 400 error`() {
+        withTestSession(authorities = listOf(AuthAuthority.ADMIN)) { admin ->
+            withTestAccount { account ->
+                mockMvc.post("/admin/accounts/${account.accountId}") {
+                    with(csrf())
+                    with(user(admin))
+
+                    param("fullName", "")
+                    param("email", account.emailAddress)
+                    param("handle", account.handle)
+                    param("authorities", account.authorities.map { it.authority }.joinToString(","))
+                }
+                    .andExpect {
+                        status {
+                            is4xxClientError()
+                        }
+                    }
+            }
+        }
+    }
+}

--- a/src/test/kotlin/org/koil/admin/accounts/UpdateAccountRequestTest.kt
+++ b/src/test/kotlin/org/koil/admin/accounts/UpdateAccountRequestTest.kt
@@ -1,0 +1,28 @@
+package org.koil.admin.accounts
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import org.junit.jupiter.api.Test
+import org.koil.auth.AuthAuthority
+import org.koil.fixtures.AccountFixtures
+
+internal class UpdateAccountRequestTest {
+    @Test
+    internal fun `updates existing account`() {
+        val account = AccountFixtures.existingAccount
+
+        val update = UpdateAccountRequest(
+            "Updated Name",
+            "updated${account.emailAddress}  ",
+            "u${account.handle}",
+            AuthAuthority.values().toList()
+        )
+
+        val result = update.update(account)
+
+        assertThat(result.fullName).isEqualTo(update.fullName)
+        assertThat(result.emailAddress).isEqualTo(update.normalizedEmail)
+        assertThat(result.handle).isEqualTo(update.handle)
+        assertThat(result.authorities.map { it.authority }).isEqualTo(update.authorities)
+    }
+}

--- a/src/webapp/cypress/integration/admin/update-details.js
+++ b/src/webapp/cypress/integration/admin/update-details.js
@@ -1,0 +1,60 @@
+const sizes = ['iphone-6', 'iphone-x', 'ipad-mini', 'macbook-13'];
+
+
+sizes.forEach(size => {
+    function isDesktopStyle() {
+        return ['ipad-mini', 'macbook-13'].includes(size)
+    }
+
+    describe(`Admin updating user details on ${size}`, () => {
+
+        beforeEach(() => {
+            cy.viewport(size)
+            cy.createRandomAccount()
+            cy.clearCookies()
+            cy.visit("/auth/login")
+        })
+
+        it('should allow an admin to update details for another user', () => {
+            cy.loginAsAdmin()
+            cy.get('@account').then(account => {
+                cy.visit("/admin?size=10000")
+                cy.get(`[data-test="account-row-${account.email}"]`)
+                    .within(() => {
+                        cy.get('[data-test=user-details]').click()
+                    })
+
+                cy.get('[data-test=user-details-form]').within(() => {
+                    let newName = 'New Name'
+                    let newEmail = `updated+${account.email}`
+                    let newHandle = `${account.slug}u`
+                    cy.get('input[name=fullName]').clear().type(newName)
+                    cy.get('input[name=email]').clear().type(newEmail)
+                    cy.get('input[name=handle]').clear().type(newHandle)
+                    cy.get('button[type=submit]').click()
+                })
+
+                cy.get('[data-test=update-confirmed]').should('exist')
+            })
+        })
+
+        it('should return an error when email is already taken', () => {
+            cy.loginAsAdmin()
+            cy.get('@account').then(account => {
+                cy.visit("/admin?size=10000")
+                cy.get(`[data-test="account-row-${account.email}"]`)
+                    .within(() => {
+                        cy.get('[data-test=user-details]').click()
+                    })
+
+                cy.get('[data-test=user-details-form]').within(() => {
+                    cy.get('input[name=email]').clear().type('admin@getkoil.dev')
+                    cy.get('button[type=submit]').click()
+                })
+
+                cy.get('[data-test=update-confirmed]').should('not.exist')
+                cy.get('[data-test=email-taken]').should('exist')
+            })
+        })
+    })
+});

--- a/src/webapp/cypress/integration/login.js
+++ b/src/webapp/cypress/integration/login.js
@@ -2,8 +2,22 @@ const sizes = ['iphone-6', 'iphone-x', 'ipad-mini', 'macbook-13'];
 
 sizes.forEach(size => {
 
-    describe(`User login flows on ${size}`, () => {
 
+    describe(` Already logged in used on ${size}`, () => {
+        beforeEach(() => {
+            cy.viewport(size)
+            cy.createRandomAccount()
+        })
+
+        it('should be redirected when visiting login page', () => {
+            cy.get('@account').then(() => {
+                cy.visit("/auth/login")
+                cy.get('[data-test=dashboard-index]').should('exist')
+            })
+        })
+    })
+
+    describe(`User login flows on ${size}`, () => {
         beforeEach(() => {
             cy.viewport(size)
             cy.createRandomAccount()

--- a/src/webapp/cypress/integration/sign-up.js
+++ b/src/webapp/cypress/integration/sign-up.js
@@ -1,32 +1,53 @@
 const sizes = ['iphone-6', 'iphone-x', 'ipad-mini', 'macbook-13'];
 sizes.forEach(size => {
 
-  describe(`User sign up flows on ${size}`, () => {
+    describe(`User sign up flows on ${size}`, () => {
 
-    beforeEach(() => {
-      cy.viewport(size)
+        beforeEach(() => {
+            cy.viewport(size)
+        })
+
+        it(`should pass the user details from the homepage to the signup page`, () => {
+            cy.visit("/");
+            cy.get('[data-test=sign-up-email]').type('test@getkoil.dev{enter}');
+            cy.get('[data-test=register-form]').within(() => {
+                cy.get('[data-test=email-input]').should('have.value', 'test@getkoil.dev')
+            })
+        });
+
+        it(`should accept a new user sign up for valid email and password`, () => {
+            cy.visit("/auth/register")
+            const slug = Math.random().toString(36).replace(/[^a-z]+/g, '').substr(0, 5);
+            cy.get('[data-test=register-form]').within(() => {
+                cy.get('[data-test=name-input]').type('Test User');
+                cy.get('[data-test=handle-input]').type(slug);
+                cy.get('[data-test=email-input]').type(`test+${slug}@getkoil.dev`);
+                cy.get('[data-test=password-input]').type('SomeSecurePass123?!');
+
+                cy.get('[data-test=submit-button]').click();
+                cy.url().should('include', '/dashboard')
+            })
+        })
+
+        it.only(`should return an error when email already taken`, () => {
+            cy.createRandomAccount()
+            cy.clearCookies()
+            cy.get('@account').then(account => {
+                cy.visit("/auth/register")
+                const slug = Math.random().toString(36).replace(/[^a-z]+/g, '').substr(0, 5);
+                cy.get('[data-test=register-form]').within(() => {
+                    cy.get('[data-test=email-error]').should('not.exist')
+
+                    cy.get('[data-test=name-input]').type('Test User');
+                    cy.get('[data-test=handle-input]').type(slug);
+                    cy.get('[data-test=email-input]').type(account.email);
+                    cy.get('[data-test=password-input]').type('SomeSecurePass123?!');
+
+                    cy.get('[data-test=submit-button]').click()
+                })
+
+                cy.get('[data-test=email-error]').should('exist')
+            })
+        })
     })
-
-    it(`should pass the user details from the homepage to the signup page`, () => {
-      cy.visit("/");
-      cy.get('[data-test=sign-up-email]').type('test@getkoil.dev{enter}');
-      cy.get('[data-test=register-form]').within(() => {
-        cy.get('[data-test=email-input]').should('have.value', 'test@getkoil.dev')
-      })
-    });
-
-    it(`should accept a new user sign up for valid email and password`, () => {
-      cy.visit("/auth/register")
-      const slug = Math.random().toString(36).replace(/[^a-z]+/g, '').substr(0, 5);
-      cy.get('[data-test=register-form]').within(() => {
-        cy.get('[data-test=name-input]').type('Test User');
-        cy.get('[data-test=handle-input]').type(slug);
-        cy.get('[data-test=email-input]').type(`test+${slug}@getkoil.dev`);
-        cy.get('[data-test=password-input]').type('SomeSecurePass123?!');
-
-        cy.get('[data-test=submit-button]').click();
-        cy.url().should('include', '/dashboard')
-      })
-    })
-  })
 });


### PR DESCRIPTION
This means that an admin can change a user's name, email or handle without impersonating them.

While this feature (and the structure) seem like overkill, the follow-up to this change is to give admins the ability to change a user's account status (e.g. to freeze or block an account).