### PR TITLE
Added the "Last-sent" dev controller endpoint.

### DIFF
--- a/src/test/kotlin/org/koil/dev/EmailDevController.kt
+++ b/src/test/kotlin/org/koil/dev/EmailDevController.kt
@@ -5,16 +5,20 @@ import org.koil.notifications.EmailDefaults
 import org.koil.notifications.NotificationAlertSuccessModel
 import org.koil.notifications.PasswordResetViewModel
 import org.springframework.context.annotation.Profile
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
+import org.springframework.mail.MailSender
 import org.springframework.stereotype.Controller
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.servlet.ModelAndView
 import java.util.*
 
 @Controller
 @Profile("dev")
 @RequestMapping("dev/email")
-class EmailDevController {
+class EmailDevController(val loggingMailSender: MailSender) {
 
     @GetMapping("/alert-success")
     fun alertSuccessEmail(): ModelAndView {
@@ -73,5 +77,17 @@ class EmailDevController {
                 )
             )
         )
+    }
+
+    @GetMapping("/last-sent")
+    fun sentEmails(@RequestParam("to") to: String?): ResponseEntity<String> {
+        val matchingEmails = (loggingMailSender as LoggingMailSender).getEmails().filter { it.to == to || to == null}
+        val email = if (matchingEmails.size > 1) {
+            matchingEmails.last().body
+        } else {
+            matchingEmails.firstOrNull()?.body ?: ""
+        }
+
+        return ResponseEntity.ok().contentType(MediaType.TEXT_HTML).body(email)
     }
 }

--- a/src/test/kotlin/org/koil/dev/LoggingMailSender.kt
+++ b/src/test/kotlin/org/koil/dev/LoggingMailSender.kt
@@ -7,13 +7,21 @@ import org.springframework.mail.javamail.JavaMailSender
 import org.springframework.mail.javamail.MimeMessagePreparator
 import java.io.InputStream
 import java.util.*
+import javax.mail.Message
 import javax.mail.Session
 import javax.mail.internet.MimeMessage
+
+data class SentEmail(val to: String, val subject: String, val body: String)
 
 class LoggingMailSender : JavaMailSender {
     companion object {
         val LOG: Logger = LoggerFactory.getLogger(LoggingMailSender::class.java)!!
     }
+
+    private val sentEmails: MutableList<SentEmail> = mutableListOf()
+
+    fun getEmails(): List<SentEmail> = sentEmails
+
 
     override fun createMimeMessage(): MimeMessage {
         return MimeMessage(Session.getDefaultInstance(Properties()))
@@ -24,11 +32,15 @@ class LoggingMailSender : JavaMailSender {
     }
 
     override fun send(mimeMessage: MimeMessage) {
+        sentEmails.add(SentEmail(mimeMessage.getRecipients(Message.RecipientType.TO).joinToString(","), mimeMessage.subject.toString(), mimeMessage.content.toString() ))
         LOG.info("Sending email $mimeMessage")
     }
 
     override fun send(vararg mimeMessages: MimeMessage?) {
         mimeMessages.forEach {
+            it?.also{ message ->
+                sentEmails.add(SentEmail(message.getRecipients(Message.RecipientType.TO).joinToString(","), message.subject.toString(), message.content.toString() ))
+            }
             LOG.info("Sending email $it")
         }
     }
@@ -44,11 +56,15 @@ class LoggingMailSender : JavaMailSender {
     }
 
     override fun send(simpleMessage: SimpleMailMessage) {
+        sentEmails.add(SentEmail(simpleMessage.to.orEmpty().joinToString(","), simpleMessage.subject.toString(), simpleMessage.text.orEmpty() ))
         LOG.info("Sending email $simpleMessage")
     }
 
     override fun send(vararg simpleMessages: SimpleMailMessage?) {
         simpleMessages.forEach {
+            it?.also{ message ->
+                sentEmails.add(SentEmail(message.to.contentToString(), message.subject.toString(), message.text.orEmpty() ))
+            }
             LOG.info("Sending email $it")
         }
     }


### PR DESCRIPTION
- This is not currently used for any tests, it's just for manual use in dev so far. It will run into concurrency issues if it's used by cypress tests that share an instance of the LoggingMailSender instance since it's an in-memory list of all sent emails.
- I decided to enrich the LoggingMailSender class instead of updating the Notifications Service because I thought it would help keep dev only code in a dev-only class. I've tested this and it seems to serve up the email properly so I think it's working pretty successfully as a solution.
- At the moment- it has a "to" filter but nothing else, it might be good to get an additional requestParam to get the "type" of the email so that you can get your "welcome" email or your "verification" email, etc.

![image](https://user-images.githubusercontent.com/41751557/140339561-b2dd6621-d092-4d82-a763-c2ceef189b75.png)
