### PR TITLE
Bugfixes required to get Heroku Deploy functioning

### DIFF
--- a/app.json
+++ b/app.json
@@ -41,12 +41,12 @@
         "description": "Password user by prometheus for http basic auth when scraping",
         "value": "prometheus"
       }
-    },
-    "formation": {
-      "web": {
-        "quantity": 1,
-        "size": "free"
-      }
+    }
+  },
+  "formation": {
+    "web": {
+      "quantity": 1,
+      "size": "free"
     }
   }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -41,7 +41,7 @@ sentry.dsn=${SENTRY_DSN}
 sentry.release=${HEROKU_SLUG_COMMIT}
 # S3 credentials
 s3.endpoint=s3://${BUCKETEER_BUCKET_NAME}
-s3.region=${BUCKETEER_AWS_SECRET_ACCESS_KEY}
+s3.region=${BUCKETEER_AWS_REGION}
 cloud.aws.credentials.access-key=${BUCKETEER_AWS_ACCESS_KEY_ID}
 cloud.aws.credentials.secret-key=${BUCKETEER_AWS_SECRET_ACCESS_KEY}
 s3.bucket-name=${BUCKETEER_BUCKET_NAME}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -40,7 +40,6 @@ management.basic-password=${PROMETHEUS_PASSWORD}
 sentry.dsn=${SENTRY_DSN}
 sentry.release=${HEROKU_SLUG_COMMIT}
 # S3 credentials
-s3.endpoint=s3://${BUCKETEER_BUCKET_NAME}
 s3.region=${BUCKETEER_AWS_REGION}
 cloud.aws.credentials.access-key=${BUCKETEER_AWS_ACCESS_KEY_ID}
 cloud.aws.credentials.secret-key=${BUCKETEER_AWS_SECRET_ACCESS_KEY}


### PR DESCRIPTION
I am very sorry for not getting this PR out last month when I figured out what the list of config issues within Koil were to get it deployed happily on Heroku.

The main changes here are around the bucketeer configuration - it looks like the variables we are provided by Heroku have changed slightly from how they originally worked. The main requirement is that we use the region in staging/prod because that is what we get from Bucketeer in the env variables - in test we still need to use the s3.endpoint because we have the minio endpoint url.

Fixed a bug where the formation must have been dragged by accident and caused issues with the app.json file.